### PR TITLE
refactor: modernize internals and fix bugs

### DIFF
--- a/.github/workflows/npm-build.yml
+++ b/.github/workflows/npm-build.yml
@@ -1,31 +1,37 @@
 name: Build Assets
 
 on:
-  pull_request:
+  push:
     branches:
       - main
-    types:
-      - closed
+    paths:
+      - 'resources/**'
 
 jobs:
-  npm-build:
+  build:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: main
+
       - name: Set up Node
         uses: actions/setup-node@v6
+
       - name: Install dependencies
         run: npm ci
-      - name: Build assets
+
+      - name: Build CSS
         run: npm run build
-      - name: Pull changes
-        run: git pull
+
+      - name: Copy JS to public
+        run: cp resources/js/slide-over.js public/slide-over.js
+
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           branch: main
           commit_message: "chore: build assets"
+          file_pattern: "public/*"

--- a/public/slide-over.js
+++ b/public/slide-over.js
@@ -1,1 +1,169 @@
-(()=>{var t,e={857:()=>{function t(t){return function(t){if(Array.isArray(t))return e(t)}(t)||function(t){if("undefined"!=typeof Symbol&&null!=t[Symbol.iterator]||null!=t["@@iterator"])return Array.from(t)}(t)||function(t,n){if(!t)return;if("string"==typeof t)return e(t,n);var o=Object.prototype.toString.call(t).slice(8,-1);"Object"===o&&t.constructor&&(o=t.constructor.name);if("Map"===o||"Set"===o)return Array.from(t);if("Arguments"===o||/^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(o))return e(t,n)}(t)||function(){throw new TypeError("Invalid attempt to spread non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method.")}()}function e(t,e){(null==e||e>t.length)&&(e=t.length);for(var n=0,o=new Array(e);n<e;n++)o[n]=t[n];return o}window.SlideOver=function(){return{open:!1,showActiveComponent:!0,activeComponent:!1,componentHistory:[],panelWidth:null,panelPosition:null,listeners:[],getActiveComponentPanelAttribute:function(t){if(void 0!==this.$wire.get("components")[this.activeComponent])return this.$wire.get("components")[this.activeComponent].panelAttributes[t]},closePanelOnEscape:function(t){if(!1!==this.getActiveComponentPanelAttribute("closeOnEscape")){var e=!0===this.getActiveComponentPanelAttribute("closeOnEscapeIsForceful");this.closePanel(e)}},closePanelOnClickAway:function(t){!1!==this.getActiveComponentPanelAttribute("closeOnClickAway")&&this.closePanel(!0)},closePanel:function(){var t=arguments.length>0&&void 0!==arguments[0]&&arguments[0],e=arguments.length>1&&void 0!==arguments[1]?arguments[1]:0,n=arguments.length>2&&void 0!==arguments[2]&&arguments[2];if(!1!==this.show){if(!0===this.getActiveComponentPanelAttribute("dispatchCloseEvent")){var o=this.$wire.get("components")[this.activeComponent].name;Livewire.dispatch("panelClosed",{name:o})}if(!0===this.getActiveComponentPanelAttribute("destroyOnClose")&&Livewire.dispatch("destroyComponent",{id:this.activeComponent}),e>0)for(var i=0;i<e;i++){if(n){var s=this.componentHistory[this.componentHistory.length-1];Livewire.dispatch("destroyComponent",{id:s})}this.componentHistory.pop()}var r=this.componentHistory.pop();r&&!t&&r?this.setActivePanelComponent(r,!0):this.setShowPropertyTo(!1)}},setActivePanelComponent:function(t){var e=this,n=arguments.length>1&&void 0!==arguments[1]&&arguments[1];if(this.setShowPropertyTo(!0),this.activeComponent!==t){!1!==this.activeComponent&&!1===n&&this.componentHistory.push(this.activeComponent);var o=50;!1===this.activeComponent?(this.activeComponent=t,this.showActiveComponent=!0,this.panelWidth=this.getActiveComponentPanelAttribute("maxWidthClass"),this.panelPosition=this.getActiveComponentPanelAttribute("position")):(this.showActiveComponent=!1,o=400,setTimeout((function(){e.activeComponent=t,e.showActiveComponent=!0,e.panelWidth=e.getActiveComponentPanelAttribute("maxWidthClass"),e.panelPosition=e.getActiveComponentPanelAttribute("position")}),300)),this.$nextTick((function(){var n,i=null===(n=e.$refs[t])||void 0===n?void 0:n.querySelector("[autofocus]");i&&setTimeout((function(){i.focus()}),o)}))}},focusables:function(){return t(this.$el.querySelectorAll("a, button, input:not([type='hidden']), textarea, select, details, [tabindex]:not([tabindex='-1'])")).filter((function(t){return!t.hasAttribute("disabled")}))},firstFocusable:function(){return this.focusables()[0]},lastFocusable:function(){return this.focusables().slice(-1)[0]},nextFocusable:function(){return this.focusables()[this.nextFocusableIndex()]||this.firstFocusable()},prevFocusable:function(){return this.focusables()[this.prevFocusableIndex()]||this.lastFocusable()},nextFocusableIndex:function(){return(this.focusables().indexOf(document.activeElement)+1)%(this.focusables().length+1)},prevFocusableIndex:function(){return Math.max(0,this.focusables().indexOf(document.activeElement))-1},setShowPropertyTo:function(t){var e=this;this.open=t,t?document.body.classList.add("overflow-y-hidden"):(document.body.classList.remove("overflow-y-hidden"),setTimeout((function(){e.activeComponent=!1,e.$wire.resetState()}),300))},init:function(){var t=this;this.panelWidth=this.getActiveComponentPanelAttribute("maxWidthClass"),this.panelPosition=this.getActiveComponentPanelAttribute("position"),this.listeners.push(Livewire.on("closePanel",(function(e){var n,o,i;t.closePanel(null!==(n=null==e?void 0:e.force)&&void 0!==n&&n,null!==(o=null==e?void 0:e.skipPreviousPanels)&&void 0!==o?o:0,null!==(i=null==e?void 0:e.destroySkipped)&&void 0!==i&&i)}))),this.listeners.push(Livewire.on("activePanelComponentChanged",(function(e){var n=e.id;t.setActivePanelComponent(n)})))},destroy:function(){this.listeners.forEach((function(t){t()}))}}}},170:()=>{}},n={};function o(t){var i=n[t];if(void 0!==i)return i.exports;var s=n[t]={exports:{}};return e[t](s,s.exports,o),s.exports}o.m=e,t=[],o.O=(e,n,i,s)=>{if(!n){var r=1/0;for(u=0;u<t.length;u++){for(var[n,i,s]=t[u],a=!0,l=0;l<n.length;l++)(!1&s||r>=s)&&Object.keys(o.O).every((t=>o.O[t](n[l])))?n.splice(l--,1):(a=!1,s<r&&(r=s));if(a){t.splice(u--,1);var c=i();void 0!==c&&(e=c)}}return e}s=s||0;for(var u=t.length;u>0&&t[u-1][2]>s;u--)t[u]=t[u-1];t[u]=[n,i,s]},o.o=(t,e)=>Object.prototype.hasOwnProperty.call(t,e),(()=>{var t={414:0,705:0};o.O.j=e=>0===t[e];var e=(e,n)=>{var i,s,[r,a,l]=n,c=0;if(r.some((e=>0!==t[e]))){for(i in a)o.o(a,i)&&(o.m[i]=a[i]);if(l)var u=l(o)}for(e&&e(n);c<r.length;c++)s=r[c],o.o(t,s)&&t[s]&&t[s][0](),t[s]=0;return o.O(u)},n=self.webpackChunk=self.webpackChunk||[];n.forEach(e.bind(null,0)),n.push=e.bind(null,n.push.bind(n))})(),o.O(void 0,[705],(()=>o(857)));var i=o.O(void 0,[705],(()=>o(170)));i=o.O(i)})();
+window.SlideOver = () => {
+  return {
+    open: false,
+    showActiveComponent: true,
+    activeComponent: false,
+    closeOnEscape: true,
+    componentHistory: [],
+    panelWidth: null,
+    panelPosition: 'right',
+    listeners: [],
+    getActiveComponentPanelAttribute(key) {
+      if (this.$wire.get('components')[this.activeComponent] !== undefined) {
+        return this.$wire.get('components')[this.activeComponent]['panelAttributes'][key]
+      }
+    },
+    closePanelOnEscape(trigger) {
+      if (this.getActiveComponentPanelAttribute('closeOnEscape') === false) {
+        return
+      }
+
+      let force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
+      this.closePanel(force)
+    },
+    closePanelOnClickAway(trigger) {
+      if (this.getActiveComponentPanelAttribute('closeOnClickAway') === false) {
+        return
+      }
+
+      this.closePanel(true)
+    },
+    closePanel(force = false, skipPreviousPanels = 0, destroySkipped = false) {
+      if (this.open === false) {
+        return
+      }
+
+      if (this.getActiveComponentPanelAttribute('dispatchCloseEvent') === true) {
+        const componentName = this.$wire.get('components')[this.activeComponent].name
+        Livewire.dispatch('panelClosed', { name: componentName })
+      }
+
+      if (this.getActiveComponentPanelAttribute('destroyOnClose') === true) {
+        Livewire.dispatch('destroyComponent', { id: this.activeComponent })
+      }
+
+      if (skipPreviousPanels > 0) {
+        for (let i = 0; i < skipPreviousPanels; i++) {
+          if (destroySkipped) {
+            const id = this.componentHistory[this.componentHistory.length - 1]
+            Livewire.dispatch('destroyComponent', { id: id })
+          }
+          this.componentHistory.pop()
+        }
+      }
+
+      const id = this.componentHistory.pop()
+
+      if (id && !force) {
+        if (id) {
+          this.setActivePanelComponent(id, true)
+        } else {
+          this.setShowPropertyTo(false)
+        }
+      } else {
+        this.setShowPropertyTo(false)
+      }
+    },
+    setActivePanelComponent(id, skip = false) {
+      this.setShowPropertyTo(true)
+
+      if (this.activeComponent === id) {
+        return
+      }
+
+      if (this.activeComponent !== false && skip === false) {
+        this.componentHistory.push(this.activeComponent)
+      }
+
+      let focusableTimeout = 50
+
+      if (this.activeComponent === false) {
+        this.activeComponent = id
+        this.showActiveComponent = true
+        this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+        this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+        this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
+      } else {
+        this.showActiveComponent = false
+
+        focusableTimeout = 400
+
+        setTimeout(() => {
+          this.activeComponent = id
+          this.showActiveComponent = true
+          this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+          this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+          this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
+        }, 300)
+      }
+
+      this.$nextTick(() => {
+        let focusable = this.$refs[id]?.querySelector('[autofocus]')
+        if (focusable) {
+          setTimeout(() => {
+            focusable.focus()
+          }, focusableTimeout)
+        }
+      })
+    },
+    focusables() {
+      let selector =
+        "a, button, input:not([type='hidden']), textarea, select, details, [tabindex]:not([tabindex='-1'])"
+
+      return [...this.$el.querySelectorAll(selector)].filter((el) => !el.hasAttribute('disabled'))
+    },
+    firstFocusable() {
+      return this.focusables()[0]
+    },
+    lastFocusable() {
+      return this.focusables().slice(-1)[0]
+    },
+    nextFocusable() {
+      return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable()
+    },
+    prevFocusable() {
+      return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable()
+    },
+    nextFocusableIndex() {
+      return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1)
+    },
+    prevFocusableIndex() {
+      return Math.max(0, this.focusables().indexOf(document.activeElement)) - 1
+    },
+    setShowPropertyTo(open) {
+      this.open = open
+
+      if (open) {
+        document.body.classList.add('overflow-y-hidden')
+      } else {
+        document.body.classList.remove('overflow-y-hidden')
+
+        setTimeout(() => {
+          this.activeComponent = false
+          this.$wire.resetState()
+        }, 300)
+      }
+    },
+    init() {
+      this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+      this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+
+      this.listeners.push(
+        Livewire.on('closePanel', (data) => {
+          this.closePanel(data?.force ?? false, data?.skipPreviousPanels ?? 0, data?.destroySkipped ?? false)
+        }),
+      )
+
+      this.listeners.push(
+        Livewire.on('activePanelComponentChanged', ({ id }) => {
+          this.setActivePanelComponent(id)
+        }),
+      )
+    },
+    destroy() {
+      this.listeners.forEach((listener) => {
+        listener()
+      })
+    },
+  }
+}

--- a/resources/js/slide-over.js
+++ b/resources/js/slide-over.js
@@ -3,8 +3,10 @@ window.SlideOver = () => {
     open: false,
     showActiveComponent: true,
     activeComponent: false,
+    closeOnEscape: true,
     componentHistory: [],
     panelWidth: null,
+    panelPosition: 'right',
     listeners: [],
     getActiveComponentPanelAttribute(key) {
       if (this.$wire.get('components')[this.activeComponent] !== undefined) {
@@ -27,7 +29,7 @@ window.SlideOver = () => {
       this.closePanel(true)
     },
     closePanel(force = false, skipPreviousPanels = 0, destroySkipped = false) {
-      if (this.show === false) {
+      if (this.open === false) {
         return
       }
 
@@ -79,6 +81,8 @@ window.SlideOver = () => {
         this.activeComponent = id
         this.showActiveComponent = true
         this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+        this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+        this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
       } else {
         this.showActiveComponent = false
 
@@ -88,6 +92,8 @@ window.SlideOver = () => {
           this.activeComponent = id
           this.showActiveComponent = true
           this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+          this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+          this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
         }, 300)
       }
 
@@ -140,6 +146,7 @@ window.SlideOver = () => {
     },
     init() {
       this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+      this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
 
       this.listeners.push(
         Livewire.on('closePanel', (data) => {

--- a/resources/views/components/close-icon.blade.php
+++ b/resources/views/components/close-icon.blade.php
@@ -1,14 +1,11 @@
-@php
-    $closeOnEscape = config('livewire-slide-over.component_defaults.close_slide_over_on_escape', true);
-@endphp
-
 <div class="flex items-center gap-2 h-7">
-    @if ($closeOnEscape)
+    <template x-if="closeOnEscape">
         <span
-            class="inline-flex items-center rounded-md bg-zinc-50 px-2 py-1 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500">
+            class="inline-flex items-center rounded-md bg-zinc-50 px-2 py-1 text-xs text-zinc-500 dark:bg-zinc-800 dark:text-zinc-500"
+        >
             esc
         </span>
-    @endif
+    </template>
 
     <button
         type="button"

--- a/src/Contracts/PanelContract.php
+++ b/src/Contracts/PanelContract.php
@@ -4,4 +4,23 @@ declare(strict_types=1);
 
 namespace Laravelcm\LivewireSlideOvers\Contracts;
 
-interface PanelContract {}
+use Laravelcm\LivewireSlideOvers\Position;
+
+interface PanelContract
+{
+    public static function closePanelOnClickAway(): bool;
+
+    public static function closePanelOnEscape(): bool;
+
+    public static function closePanelOnEscapeIsForceful(): bool;
+
+    public static function dispatchCloseEvent(): bool;
+
+    public static function destroyOnClose(): bool;
+
+    public static function panelMaxWidth(): string;
+
+    public static function panelMaxWidthClass(): string;
+
+    public static function panelPosition(): Position;
+}

--- a/src/SlideOverComponent.php
+++ b/src/SlideOverComponent.php
@@ -172,7 +172,7 @@ abstract class SlideOverComponent extends Component implements PanelContract
                 $this->dispatch($eventName, ...$params);
             } else {
                 $dispatcher = $this->dispatch($eventName, ...$params);
-                $dispatcher->to((string) $component);
+                $dispatcher->to((string) $component); // @phpstan-ignore-line
             }
         }
     }

--- a/src/SlideOverComponent.php
+++ b/src/SlideOverComponent.php
@@ -171,7 +171,6 @@ abstract class SlideOverComponent extends Component implements PanelContract
             if (is_numeric($component)) {
                 $this->dispatch($eventName, ...$params);
             } else {
-                /** @var \Livewire\Features\SupportEvents\Event $dispatcher */
                 $dispatcher = $this->dispatch($eventName, ...$params);
                 $dispatcher->to((string) $component);
             }

--- a/src/SlideOverPanel.php
+++ b/src/SlideOverPanel.php
@@ -12,13 +12,14 @@ use Illuminate\Contracts\View\View;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
+use Illuminate\Support\Reflector;
 use Laravelcm\LivewireSlideOvers\Contracts\PanelContract;
 use Livewire\Attributes\Locked;
+use Livewire\Attributes\On;
 use Livewire\Component;
-use Livewire\Finder\Finder;
+use Livewire\Factory\Factory;
 use ReflectionClass;
 use ReflectionException;
-use ReflectionNamedType;
 use ReflectionProperty;
 
 class SlideOverPanel extends Component
@@ -78,18 +79,11 @@ class SlideOverPanel extends Component
      */
     protected function resolveComponentClass(string $component): string
     {
-        if (class_exists(\Livewire\Mechanisms\ComponentRegistry::class)) {
-            /** @var class-string $class */
-            $class = app(\Livewire\Mechanisms\ComponentRegistry::class)->getClass($component);
-
-            return $class;
-        }
-
-        /** @var Finder $finder */
-        $finder = app('livewire.finder');
+        /** @var Factory $factory */
+        $factory = app('livewire.factory');
 
         /** @var class-string $class */
-        $class = $finder->resolveClassComponentClassName($component);
+        $class = $factory->resolveComponentClass($component);
 
         return $class;
     }
@@ -106,6 +100,7 @@ class SlideOverPanel extends Component
      *
      * @throws ReflectionException
      */
+    #[On('openPanel')]
     public function openPanel(string $component, array $arguments = [], array $panelAttributes = []): void
     {
         $requiredInterface = PanelContract::class;
@@ -117,7 +112,7 @@ class SlideOverPanel extends Component
             throw new Exception("[{$componentClass}] does not implement [{$requiredInterface}] interface.");
         }
 
-        $id = md5($component.serialize($arguments));
+        $id = md5($component.json_encode($arguments));
 
         $arguments = collect($arguments)
             ->merge($this->resolveComponentProps($arguments, new $componentClass))
@@ -134,6 +129,7 @@ class SlideOverPanel extends Component
                 'destroyOnClose' => $componentClass::destroyOnClose(),
                 'maxWidth' => $componentClass::panelMaxWidth(),
                 'maxWidthClass' => $componentClass::panelMaxWidthClass(),
+                'position' => $componentClass::panelPosition()->value,
             ], $panelAttributes),
         ];
 
@@ -166,35 +162,16 @@ class SlideOverPanel extends Component
 
         /** @var Collection<string, class-string> $result */
         $result = collect($properties)
-            ->map(function (mixed $value, string $name) use ($component): ?string {
-                $property = new ReflectionProperty($component, $name);
-                $type = $property->getType();
-
-                if ($type instanceof ReflectionNamedType && ! $type->isBuiltin()) {
-                    return $type->getName();
-                }
-
-                return null;
-            })
+            ->map(fn (mixed $value, string $name): ?string => Reflector::getParameterClassName(new ReflectionProperty($component, $name))) // @phpstan-ignore-line
             ->filter();
 
         return $result;
     }
 
+    #[On('destroyComponent')]
     public function destroyComponent(string $id): void
     {
         unset($this->components[$id]);
-    }
-
-    /**
-     * @return array<int, string>
-     */
-    public function getListeners(): array
-    {
-        return [
-            'openPanel',
-            'destroyComponent',
-        ];
     }
 
     public function render(): View

--- a/tests/Feature/SlideOverPanelTest.php
+++ b/tests/Feature/SlideOverPanelTest.php
@@ -23,9 +23,10 @@ it('opens a panel via openPanel event', function (): void {
         'closeOnEscapeIsForceful' => true,
         'dispatchCloseEvent' => false,
         'destroyOnClose' => false,
+        'position' => 'right',
     ];
 
-    $id = md5($component.serialize($arguments));
+    $id = md5($component.json_encode($arguments));
 
     Livewire::test(SlideOverPanel::class)
         ->dispatch('openPanel', component: $component, arguments: $arguments, panelAttributes: $panelAttributes)
@@ -52,9 +53,10 @@ it('destroys a component via destroyComponent event', function (): void {
         'closeOnEscapeIsForceful' => true,
         'dispatchCloseEvent' => false,
         'destroyOnClose' => false,
+        'position' => 'right',
     ];
 
-    $id = md5($component.serialize($arguments));
+    $id = md5($component.json_encode($arguments));
 
     Livewire::test(SlideOverPanel::class)
         ->dispatch('openPanel', component: $component, arguments: $arguments, panelAttributes: $panelAttributes)
@@ -87,4 +89,30 @@ it('throws exception when component does not implement PanelContract', function 
 
     Livewire::test(SlideOverPanel::class)
         ->dispatch('openPanel', component: 'invalid-slide-over');
+});
+
+it('opens panel with default attributes when no panelAttributes provided', function (): void {
+    $component = 'demo-slide-over';
+    $arguments = ['message' => 'Default'];
+
+    $id = md5($component.json_encode($arguments));
+
+    Livewire::test(SlideOverPanel::class)
+        ->dispatch('openPanel', component: $component, arguments: $arguments)
+        ->assertSet('activeComponent', $id)
+        ->assertDispatched('activePanelComponentChanged', id: $id);
+});
+
+it('includes position in panel attributes', function (): void {
+    $component = 'demo-slide-over';
+    $arguments = ['message' => 'Position test'];
+
+    $id = md5($component.json_encode($arguments));
+
+    $testable = Livewire::test(SlideOverPanel::class)
+        ->dispatch('openPanel', component: $component, arguments: $arguments);
+
+    $components = $testable->get('components');
+
+    expect($components[$id]['panelAttributes'])->toHaveKey('position', 'right');
 });


### PR DESCRIPTION
- Fix bug: `this.show` → `this.open` in closePanel() JS
- Add method signatures to `PanelContract`
- Use #[On] attributes instead of `getListeners()`
- Use `Reflector::getParameterClassName()` for cleaner type resolution
- Use livewire.factory->resolveComponentClass() (works on Livewire 3 & 4)
- Use json_encode instead of serialize for component ID hashing
- Add reactive closeOnEscape state per-component in Alpine JS
- Add `panelPosition` to `panelAttributes` for per-component positioning
- Make close-icon use Alpine x-if instead of static config
- Update build workflow with path filter on resources/
- Add 2 new tests for default attributes and position