### PR TITLE
feat: add stacked panels support

### DIFF
--- a/config/livewire-slide-over.php
+++ b/config/livewire-slide-over.php
@@ -44,6 +44,19 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Stacked Panels
+    |--------------------------------------------------------------------------
+    |
+    | When enabled, opening a new panel while one is already open will visually
+    | stack them: previous panels remain visible but scale down and shift aside,
+    | creating a depth effect. When disabled (default), only the active panel
+    | is visible and previous panels are hidden.
+    |
+    */
+    'stack' => true,
+
+    /*
+    |--------------------------------------------------------------------------
     | Slide Over Component Defaults
     |--------------------------------------------------------------------------
     |

--- a/public/slide-over.js
+++ b/public/slide-over.js
@@ -55,6 +55,12 @@ window.SlideOver = () => {
       }
 
       let force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
+
+      if (this.stacked && this.componentHistory.length > 0) {
+        this.closePanel(false)
+        return
+      }
+
       this.closePanel(force)
     },
     closePanelOnClickAway(trigger) {

--- a/public/slide-over.js
+++ b/public/slide-over.js
@@ -7,10 +7,46 @@ window.SlideOver = () => {
     componentHistory: [],
     panelWidth: null,
     panelPosition: 'right',
+    stacked: false,
     listeners: [],
     getActiveComponentPanelAttribute(key) {
       if (this.$wire.get('components')[this.activeComponent] !== undefined) {
         return this.$wire.get('components')[this.activeComponent]['panelAttributes'][key]
+      }
+    },
+    getComponentPanelAttribute(id, key) {
+      const components = this.$wire.get('components')
+      if (components[id] !== undefined) {
+        return components[id]['panelAttributes'][key]
+      }
+    },
+    isComponentVisible(id) {
+      return id === this.activeComponent || this.componentHistory.includes(id)
+    },
+    getStackIndex(id) {
+      if (id === this.activeComponent) {
+        return 0
+      }
+
+      const historyIndex = this.componentHistory.indexOf(id)
+      if (historyIndex === -1) {
+        return -1
+      }
+
+      return this.componentHistory.length - historyIndex
+    },
+    getStackStyle(id) {
+      const index = this.getStackIndex(id)
+      if (index <= 0) {
+        return {}
+      }
+
+      const position = this.getComponentPanelAttribute(id, 'position') ?? 'right'
+      const dx = position === 'left' ? 1 : -1
+
+      return {
+        transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (2 * dx * index) + 'rem)',
+        opacity: index <= 2 ? 1 : 0,
       }
     },
     closePanelOnEscape(trigger) {
@@ -84,7 +120,9 @@ window.SlideOver = () => {
         this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
         this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
       } else {
-        this.showActiveComponent = false
+        if (!this.stacked) {
+          this.showActiveComponent = false
+        }
 
         focusableTimeout = 400
 
@@ -94,7 +132,7 @@ window.SlideOver = () => {
           this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
           this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
           this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
-        }, 300)
+        }, this.stacked ? 0 : 300)
       }
 
       this.$nextTick(() => {
@@ -140,6 +178,7 @@ window.SlideOver = () => {
 
         setTimeout(() => {
           this.activeComponent = false
+          this.componentHistory = []
           this.$wire.resetState()
         }, 300)
       }
@@ -147,6 +186,7 @@ window.SlideOver = () => {
     init() {
       this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
       this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+      this.stacked = this.$el.dataset.stacked === 'true'
 
       this.listeners.push(
         Livewire.on('closePanel', (data) => {

--- a/resources/js/slide-over.js
+++ b/resources/js/slide-over.js
@@ -55,6 +55,12 @@ window.SlideOver = () => {
       }
 
       let force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
+
+      if (this.stacked && this.componentHistory.length > 0) {
+        this.closePanel(false)
+        return
+      }
+
       this.closePanel(force)
     },
     closePanelOnClickAway(trigger) {

--- a/resources/js/slide-over.js
+++ b/resources/js/slide-over.js
@@ -7,10 +7,46 @@ window.SlideOver = () => {
     componentHistory: [],
     panelWidth: null,
     panelPosition: 'right',
+    stacked: false,
     listeners: [],
     getActiveComponentPanelAttribute(key) {
       if (this.$wire.get('components')[this.activeComponent] !== undefined) {
         return this.$wire.get('components')[this.activeComponent]['panelAttributes'][key]
+      }
+    },
+    getComponentPanelAttribute(id, key) {
+      const components = this.$wire.get('components')
+      if (components[id] !== undefined) {
+        return components[id]['panelAttributes'][key]
+      }
+    },
+    isComponentVisible(id) {
+      return id === this.activeComponent || this.componentHistory.includes(id)
+    },
+    getStackIndex(id) {
+      if (id === this.activeComponent) {
+        return 0
+      }
+
+      const historyIndex = this.componentHistory.indexOf(id)
+      if (historyIndex === -1) {
+        return -1
+      }
+
+      return this.componentHistory.length - historyIndex
+    },
+    getStackStyle(id) {
+      const index = this.getStackIndex(id)
+      if (index <= 0) {
+        return {}
+      }
+
+      const position = this.getComponentPanelAttribute(id, 'position') ?? 'right'
+      const dx = position === 'left' ? 1 : -1
+
+      return {
+        transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (2 * dx * index) + 'rem)',
+        opacity: index <= 2 ? 1 : 0,
       }
     },
     closePanelOnEscape(trigger) {
@@ -84,7 +120,9 @@ window.SlideOver = () => {
         this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
         this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
       } else {
-        this.showActiveComponent = false
+        if (!this.stacked) {
+          this.showActiveComponent = false
+        }
 
         focusableTimeout = 400
 
@@ -94,7 +132,7 @@ window.SlideOver = () => {
           this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
           this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
           this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
-        }, 300)
+        }, this.stacked ? 0 : 300)
       }
 
       this.$nextTick(() => {
@@ -140,6 +178,7 @@ window.SlideOver = () => {
 
         setTimeout(() => {
           this.activeComponent = false
+          this.componentHistory = []
           this.$wire.resetState()
         }, 300)
       }
@@ -147,6 +186,7 @@ window.SlideOver = () => {
     init() {
       this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
       this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+      this.stacked = this.$el.dataset.stacked === 'true'
 
       this.listeners.push(
         Livewire.on('closePanel', (data) => {

--- a/resources/views/slide-over.blade.php
+++ b/resources/views/slide-over.blade.php
@@ -3,6 +3,7 @@
 
     $position = config('livewire-slide-over.position', Position::Right);
     $isLeft = $position === Position::Left;
+    $isStacked = config('livewire-slide-over.stack', false);
 @endphp
 
 <div>
@@ -20,6 +21,7 @@
 
     <section
         x-data="SlideOver()"
+        data-stacked="{{ $isStacked ? 'true' : 'false' }}"
         x-on:close.stop="setShowPropertyTo(false)"
         x-on:keydown.escape.window="closePanelOnEscape()"
         x-show="open"
@@ -42,46 +44,85 @@
         ></div>
 
         <div class="fixed inset-0">
-            <div
-                @class([
-                    'pointer-events-none fixed inset-y-0 flex max-w-full py-2',
-                    'left-0 pl-2 pr-10' => $isLeft,
-                    'right-0 pr-2 pl-10' => ! $isLeft,
-                ])
-            >
+            @if ($isStacked)
                 <div
-                    x-cloak
-                    x-show="open && showActiveComponent"
-                    x-transition:enter="transform transition duration-500 ease-in-out"
-                    x-transition:enter-start="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                    x-transition:enter-end="translate-x-0"
-                    x-transition:leave="transform transition duration-500 ease-in-out"
-                    x-transition:leave-start="translate-x-0"
-                    x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                    class="pointer-events-auto w-screen"
-                    x-bind:class="panelWidth"
-                    x-trap.noscroll.inert="open && showActiveComponent"
-                    @click.away="closePanelOnClickAway()"
-                    aria-modal="true"
+                    @class([
+                        'pointer-events-none fixed inset-y-0 grid max-w-full py-2',
+                        'left-0 pl-2 pr-10' => $isLeft,
+                        'right-0 pr-2 pl-10' => ! $isLeft,
+                    ])
+                    style="grid-template-areas: 'stack'"
                 >
-                    <div
-                        class="h-full overflow-hidden rounded-xl bg-zinc-50 shadow-lg ring-1 ring-zinc-950/20 p-1.5 dark:bg-zinc-950 dark:ring-white/10"
-                    >
-                        @forelse ($components as $id => $component)
+                    @forelse ($components as $id => $component)
+                        <div
+                            x-show="open && isComponentVisible('{{ $id }}')"
+                            x-transition:enter="transform transition duration-500 ease-in-out"
+                            x-transition:enter-start="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
+                            x-transition:enter-end="translate-x-0"
+                            x-transition:leave="transform transition duration-500 ease-in-out"
+                            x-transition:leave-start="translate-x-0"
+                            x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
+                            class="pointer-events-auto w-screen"
+                            x-bind:class="getComponentPanelAttribute('{{ $id }}', 'maxWidthClass') ?? panelWidth"
+                            style="grid-area: stack"
+                            wire:key="{{ $id }}"
+                        >
                             <div
-                                class="size-full min-w-0 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-zinc-950/20 dark:bg-zinc-900 dark:ring-white/10"
-                                x-show.immediate="activeComponent == '{{ $id }}'"
+                                class="h-full transition-[transform,opacity] duration-300 ease-in-out"
+                                x-bind:style="getStackStyle('{{ $id }}')"
+                                x-bind:inert="activeComponent !== '{{ $id }}'"
+                                x-trap="activeComponent === '{{ $id }}'"
                                 x-ref="{{ $id }}"
-                                wire:key="{{ $id }}"
                             >
                                 @livewire($component['name'], $component['arguments'], key($id))
                             </div>
-                        @empty
+                        </div>
+                    @empty
 
-                        @endforelse
+                    @endforelse
+                </div>
+            @else
+                <div
+                    @class([
+                        'pointer-events-none fixed inset-y-0 flex max-w-full py-2',
+                        'left-0 pl-2 pr-10' => $isLeft,
+                        'right-0 pr-2 pl-10' => ! $isLeft,
+                    ])
+                >
+                    <div
+                        x-cloak
+                        x-show="open && showActiveComponent"
+                        x-transition:enter="transform transition duration-500 ease-in-out"
+                        x-transition:enter-start="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
+                        x-transition:enter-end="translate-x-0"
+                        x-transition:leave="transform transition duration-500 ease-in-out"
+                        x-transition:leave-start="translate-x-0"
+                        x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
+                        class="pointer-events-auto w-screen"
+                        x-bind:class="panelWidth"
+                        x-trap.noscroll.inert="open && showActiveComponent"
+                        @click.away="closePanelOnClickAway()"
+                        aria-modal="true"
+                    >
+                        <div
+                            class="h-full overflow-hidden rounded-xl bg-zinc-50 shadow-lg ring-1 ring-zinc-950/20 p-1.5 dark:bg-zinc-950 dark:ring-white/10"
+                        >
+                            @forelse ($components as $id => $component)
+                                <div
+                                    class="size-full min-w-0 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-zinc-950/20 dark:bg-zinc-900 dark:ring-white/10"
+                                    x-show.immediate="activeComponent == '{{ $id }}'"
+                                    x-ref="{{ $id }}"
+                                    wire:key="{{ $id }}"
+                                >
+                                    @livewire($component['name'], $component['arguments'], key($id))
+                                </div>
+                            @empty
+
+                            @endforelse
+                        </div>
                     </div>
                 </div>
-            </div>
+            @endif
         </div>
     </section>
 </div>


### PR DESCRIPTION
## Summary

- Add `stack` config option (default: `false`) to enable visual stacking
- When enabled, opening a new slide-over from within an existing one creates a depth effect: previous panels remain visible but scale down and shift aside
- Non-stacked mode is completely unchanged — two separate rendering paths in the Blade view, zero regression risk
- Stacked panels are unstyled containers — developers control the look of their components (rounded, shadow, bg, etc.)

### How it works

**CSS Grid stacking**: panels overlap via `grid-area: stack`, inspired by [ElegantEngineeringTech/livewire-modal](https://github.com/ElegantEngineeringTech/livewire-modal)

**Two-div architecture** per panel in stacked mode:
- Outer div: handles slide-in/out animation (`x-transition` with `translateX`)
- Inner div: handles depth effect (`transition` CSS with `scale()` + `translateX()`)

This avoids the `transform` conflict between Alpine transitions and inline styles.

### New JS methods

- `isComponentVisible(id)` — visible if active or in history
- `getStackIndex(id)` — 0 = active, 1 = previous, 2 = before that...
- `getStackStyle(id)` — returns `{transform, opacity}` based on index
- `getComponentPanelAttribute(id, key)` — read attribute for any component

### Usage

```php
// config/livewire-slide-over.php
'stack' => true,
```

Then open a slide-over from within another slide-over as usual:

```php
$this->dispatch('openPanel', component: 'my-other-panel');
```