### PR TITLE
fix: support both Livewire 3.x and 4.x component resolution

### DIFF
--- a/src/SlideOverPanel.php
+++ b/src/SlideOverPanel.php
@@ -17,7 +17,6 @@ use Laravelcm\LivewireSlideOvers\Contracts\PanelContract;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
 use Livewire\Component;
-use Livewire\Factory\Factory;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionProperty;
@@ -79,11 +78,16 @@ class SlideOverPanel extends Component
      */
     protected function resolveComponentClass(string $component): string
     {
-        /** @var Factory $factory */
-        $factory = app('livewire.factory');
+        // Livewire 4.x uses livewire.factory, Livewire 3.x uses ComponentRegistry
+        if (app()->bound('livewire.factory')) {
+            /** @var class-string $class */
+            $class = app('livewire.factory')->resolveComponentClass($component); // @phpstan-ignore-line
+
+            return $class;
+        }
 
         /** @var class-string $class */
-        $class = $factory->resolveComponentClass($component);
+        $class = app('Livewire\Mechanisms\ComponentRegistry')->getClass($component); // @phpstan-ignore-line
 
         return $class;
     }


### PR DESCRIPTION
## Summary

- Livewire 3.x uses `Livewire\Mechanisms\ComponentRegistry` to resolve component classes
- Livewire 4.x uses `livewire.factory` binding with `resolveComponentClass()`
- The v2.0 release broke Livewire 3.x by only using `livewire.factory`
- This fix checks which binding exists at runtime to support both versions