### PR TITLE
fix: stacked panel overflow and initialize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+All notable changes to `livewire-slide-overs` will be documented in this file.
+
+## v2.0.1 - 2026-03-17
+
+- fix: support both Livewire 3.x and 4.x component resolution (#13)
+
+## v2.0.0 - 2026-03-16
+
+### Breaking Changes
+
+- `PanelContract` now defines method signatures (was an empty marker interface)
+- Component ID hashing changed from `serialize()` to `json_encode()`
+- `getListeners()` replaced by `#[On]` attributes
+
+### New Features
+
+- Stacked panels support (`'stack' => true` in config)
+- Per-component position in panelAttributes
+
+### Improvements
+
+- Bug fix: `this.show` → `this.open` in closePanel() JS
+- Escape key closes only active panel in stacked mode
+- Modern Livewire: `#[On]` attributes
+- Cleaner type resolution: `Reflector::getParameterClassName()`
+- Reactive close-icon: Alpine `x-if="closeOnEscape"` per-component
+- Build workflow: path filter on `resources/`
+- 2 new tests

--- a/resources/views/slide-over.blade.php
+++ b/resources/views/slide-over.blade.php
@@ -62,7 +62,7 @@
                             x-transition:leave="transform transition duration-500 ease-in-out"
                             x-transition:leave-start="translate-x-0"
                             x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                            class="pointer-events-auto w-screen"
+                            class="pointer-events-auto min-h-0 w-screen"
                             x-bind:class="getComponentPanelAttribute('{{ $id }}', 'maxWidthClass') ?? panelWidth"
                             style="grid-area: stack"
                             wire:key="{{ $id }}"


### PR DESCRIPTION
## Summary

- **Stacked overflow fix**: Add `min-h-0` to stacked grid items. CSS Grid items have `min-height: auto` by default which prevents them from shrinking below their content size. This caused panels with long content to overflow the viewport instead of scrolling. `min-h-0` allows the grid item to respect the grid cell height and let children handle overflow.
- **Changelog**: Initialize `CHANGELOG.md` with proper headings so the `changelog-updater-action` can insert release notes (was failing on v2.0.0 and v2.0.1 releases because the file was empty).

No impact on non-stacked mode (this code is inside `@if ($isStacked)`).