### PR TITLE
fix: safelist max-width classes for Tailwind v4

### DIFF
--- a/resources/css/slide-over.css
+++ b/resources/css/slide-over.css
@@ -1,6 +1,7 @@
 @import "tailwindcss";
 
 @source "../views";
+@source inline("max-w-{sm,md,lg,xl,2xl,3xl,4xl,5xl,6xl,7xl}");
 
 @custom-variant dark (&:where(.dark, .dark *));
 


### PR DESCRIPTION
## Summary

Panel max-width classes (`max-w-sm` through `max-w-7xl`) are applied dynamically via Alpine `x-bind:class`, so Tailwind can't detect them during source scanning.

Uses `@source inline()` in the package CSS to ensure all max-width variants are always generated.