### PR TITLE
fix: stacked slide-over UX (ESC pops single panel, responsive width)

### DIFF
--- a/public/slide-over.js
+++ b/public/slide-over.js
@@ -43,9 +43,10 @@ window.SlideOver = () => {
 
       const position = this.getComponentPanelAttribute(id, 'position') ?? 'right'
       const dx = position === 'left' ? 1 : -1
+      const offset = window.innerWidth < 640 ? 0.5 : 2
 
       return {
-        transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (2 * dx * index) + 'rem)',
+        transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (offset * dx * index) + 'rem)',
         opacity: index <= 2 ? 1 : 0,
       }
     },
@@ -56,7 +57,7 @@ window.SlideOver = () => {
 
       let force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
 
-      if (this.stacked && this.componentHistory.length > 0) {
+      if (this.componentHistory.length > 0) {
         this.closePanel(false)
         return
       }

--- a/resources/js/slide-over.js
+++ b/resources/js/slide-over.js
@@ -43,9 +43,10 @@ window.SlideOver = () => {
 
       const position = this.getComponentPanelAttribute(id, 'position') ?? 'right'
       const dx = position === 'left' ? 1 : -1
+      const offset = window.innerWidth < 640 ? 0.5 : 2
 
       return {
-        transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (2 * dx * index) + 'rem)',
+        transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (offset * dx * index) + 'rem)',
         opacity: index <= 2 ? 1 : 0,
       }
     },
@@ -56,7 +57,7 @@ window.SlideOver = () => {
 
       let force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
 
-      if (this.stacked && this.componentHistory.length > 0) {
+      if (this.componentHistory.length > 0) {
         this.closePanel(false)
         return
       }

--- a/resources/views/slide-over.blade.php
+++ b/resources/views/slide-over.blade.php
@@ -62,7 +62,7 @@
                             x-transition:leave="transform transition duration-500 ease-in-out"
                             x-transition:leave-start="translate-x-0"
                             x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                            class="pointer-events-auto min-h-0 w-screen"
+                            class="pointer-events-auto min-h-0 w-[calc(100vw-3rem)] sm:w-screen"
                             x-bind:class="getComponentPanelAttribute('{{ $id }}', 'maxWidthClass') ?? panelWidth"
                             style="grid-area: stack"
                             wire:key="{{ $id }}"
@@ -98,18 +98,18 @@
                         x-transition:leave="transform transition duration-500 ease-in-out"
                         x-transition:leave-start="translate-x-0"
                         x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                        class="pointer-events-auto w-screen"
+                        class="pointer-events-auto w-[calc(100vw-3rem)] sm:w-screen"
                         x-bind:class="panelWidth"
                         x-trap.noscroll.inert="open && showActiveComponent"
                         @click.away="closePanelOnClickAway()"
                         aria-modal="true"
                     >
                         <div
-                            class="h-full overflow-hidden rounded-xl bg-zinc-50 shadow-lg ring-1 ring-zinc-950/20 p-1.5 dark:bg-zinc-950 dark:ring-white/10"
+                            class="h-full overflow-hidden rounded-xl bg-zinc-50 shadow-lg ring-1 ring-zinc-950/20 p-1 dark:bg-zinc-950 dark:ring-white/10"
                         >
                             @forelse ($components as $id => $component)
                                 <div
-                                    class="size-full min-w-0 overflow-hidden rounded-md bg-white shadow-lg ring-1 ring-zinc-950/20 dark:bg-zinc-900 dark:ring-white/10"
+                                    class="size-full min-w-0 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-zinc-950/20 dark:bg-zinc-900 dark:ring-white/10"
                                     x-show.immediate="activeComponent == '{{ $id }}'"
                                     x-ref="{{ $id }}"
                                     wire:key="{{ $id }}"


### PR DESCRIPTION
## Summary

Two related fixes for stacked slide-overs.

### 1. ESC closes all panels instead of popping one

The escape handler was gated on `this.stacked &&` before checking history. When `stacked` was unset/false (or in non-stacked mode with multiple panels in history), it fell through to `closePanel(force)` where `force = closeOnEscapeIsForceful` — which defaults to `true` in the package config. Result: pressing ESC always force-closed every panel via `setShowPropertyTo(false)`.

Fix: pop the topmost panel from `componentHistory` whenever it has entries, regardless of stack mode. Force only applies when no history remains (the last panel).

```diff
- if (this.stacked && this.componentHistory.length > 0) {
+ if (this.componentHistory.length > 0) {
    this.closePanel(false)
    return
  }
```

### 2. Stack overflows the viewport on mobile

In stacked mode, background panels were translated by `2rem * index` and rendered at `w-screen`. On narrow screens, the offset pushed previous panels off-canvas and the active panel covered them entirely — defeating the visual stack effect.

Fix:
- `getStackStyle`: offset becomes `0.5rem` when `window.innerWidth < 640`, stays at `2rem` otherwise.
- Panel width: `w-[calc(100vw-3rem)] sm:w-screen` (applied to both stacked and non-stacked panel wrappers) so the 3rem gutter exposes background panels and gives a visible affordance to dismiss.