### PR TITLE
feat: instant open, dynamic resize, native dialog mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,24 @@ To open a slide over you will need to dispatch an event. To open the `ShoppingCa
 <button wire:click="$dispatch('openPanel', { component: 'shop.actions.shopping-cart' })">View cart</button>
 ```
 
+### Instant Open (Optimistic UI)
+
+Dispatching `openPanel` waits for a full Livewire round-trip before the drawer animates. The `window.$slideOver` helper opens the drawer chrome immediately while the Livewire content hydrates inside it during the slide transition:
+
+```blade
+<button onclick="$slideOver.open('shopping-cart')">View cart</button>
+
+<!-- With arguments -->
+<button onclick="$slideOver.open('edit-user', { user: {{ $user->id }} })">Edit user</button>
+
+<!-- With panel attribute overrides -->
+<button onclick="$slideOver.open('shopping-cart', {}, { maxWidthClass: 'max-w-2xl' })">View cart</button>
+```
+
+**How the cache works.** No registration or config is required. The first time a given component is opened in a session, the helper falls back to a standard Livewire round-trip (the drawer can't animate without knowing its width and position). Once the server response returns, the resolved panel attributes are stored in `sessionStorage`, and every subsequent open of the same component during that session is instant.
+
+If you want the very first open to be instant too, pass the relevant attributes explicitly as the third argument — they bypass the cache and let the helper animate immediately.
+
 ## Passing Data
 
 You can pass data to the slide over component by adding an `arguments` object to the dispatch event:
@@ -119,6 +137,37 @@ class EditUser extends SlideOverComponent
 ```
 
 Model binding is automatic - just type-hint the model and pass the ID as the argument.
+
+## Resizing a Slide Over Dynamically
+
+A slide over's width is normally set once via `panelMaxWidth()` on the component class. To change the width while the panel is open (for example, expanding when the user reveals additional content), call `resizePanel()` from your component:
+
+```php
+public function loadDetails(): void
+{
+    // ... fetch data ...
+
+    // Expand the panel to give the new content some room.
+    $this->resizePanel('max-w-6xl');
+}
+
+public function clearDetails(): void
+{
+    // ... reset ...
+
+    $this->resizePanel('max-w-2xl');
+}
+```
+
+The argument is a Tailwind max-width utility class (`max-w-sm` through `max-w-7xl`) or any arbitrary class string — including JIT values such as `max-w-[800px]`. The change is applied client-side via a smooth CSS transition; no full re-render of the panel is required.
+
+To target a specific panel in a stacked configuration, pass its id as the second argument:
+
+```php
+$this->resizePanel('max-w-4xl', $panelId);
+```
+
+When omitted, the currently active panel is resized.
 
 ## Closing the Slide Over
 

--- a/resources/js/slide-over.js
+++ b/resources/js/slide-over.js
@@ -1,125 +1,260 @@
-window.SlideOver = () => {
+// === Common ===
+
+const slideOverCommon = {
+  open: false,
+  activeComponent: false,
+  componentHistory: [],
+  closeOnEscape: true,
+  panelWidth: null,
+  panelPosition: 'right',
+  showActiveComponent: true,
+  listeners: [],
+  optimisticComponents: {},
+  optimisticTimeouts: {},
+  resizedComponents: {},
+  optimisticTimeoutMs: 10000,
+  cacheKey: 'livewire-slide-over-cache',
+  _closeCleanupTimeout: null,
+
+  cancelCloseCleanup() {
+    if (this._closeCleanupTimeout) {
+      clearTimeout(this._closeCleanupTimeout)
+      this._closeCleanupTimeout = null
+    }
+  },
+
+  readCache() {
+    try {
+      return JSON.parse(window.sessionStorage.getItem(this.cacheKey) || '{}')
+    } catch (e) {
+      return {}
+    }
+  },
+  writeCache(component, panelAttributes) {
+    try {
+      const cache = this.readCache()
+      cache[component] = panelAttributes
+      window.sessionStorage.setItem(this.cacheKey, JSON.stringify(cache))
+    } catch (e) {}
+  },
+  stableStringify(value) {
+    if (value === null || typeof value !== 'object') return JSON.stringify(value)
+    if (Array.isArray(value)) return '[' + value.map((v) => this.stableStringify(v)).join(',') + ']'
+    const keys = Object.keys(value).sort()
+    return '{' + keys.map((k) => JSON.stringify(k) + ':' + this.stableStringify(value[k])).join(',') + '}'
+  },
+  deriveId(name, args) {
+    const str = name + ':' + this.stableStringify(args ?? {})
+    let fnv = 0x811c9dc5
+    let djb = 5381
+    for (let i = 0; i < str.length; i++) {
+      const c = str.charCodeAt(i)
+      fnv = Math.imul(fnv ^ c, 0x01000193)
+      djb = ((djb << 5) + djb + c) | 0
+    }
+    return 'so-' + (fnv >>> 0).toString(36) + '-' + (djb >>> 0).toString(36)
+  },
+  getPanelState(id) {
+    if (id === this.activeComponent) return 'active'
+    if (this.componentHistory.includes(id)) return 'behind'
+    return 'ahead'
+  },
+  getActiveComponentPanelAttribute(key) {
+    return this.getComponentPanelAttribute(this.activeComponent, key)
+  },
+  getComponentPanelAttribute(id, key) {
+    if (key === 'maxWidthClass' && this.resizedComponents[id] !== undefined) {
+      return this.resizedComponents[id]
+    }
+    if (this.optimisticComponents[id] !== undefined) {
+      return this.optimisticComponents[id]['panelAttributes'][key]
+    }
+    const components = this.$wire.get('components')
+    if (components[id] !== undefined) {
+      return components[id]['panelAttributes'][key]
+    }
+  },
+  scheduleOptimisticTimeout(id) {
+    this.clearOptimisticTimeout(id)
+    this.optimisticTimeouts[id] = setTimeout(() => {
+      if (this.optimisticComponents[id]) {
+        delete this.optimisticComponents[id]
+        if (this.activeComponent === id) this.closePanel(true)
+      }
+      delete this.optimisticTimeouts[id]
+    }, this.optimisticTimeoutMs)
+  },
+  clearOptimisticTimeout(id) {
+    if (this.optimisticTimeouts[id]) {
+      clearTimeout(this.optimisticTimeouts[id])
+      delete this.optimisticTimeouts[id]
+    }
+  },
+  openOptimistically(component, args, attrs, id) {
+    const cached = this.readCache()[component]
+    if (!cached && Object.keys(attrs).length === 0) {
+      Livewire.dispatch('openPanel', { component, arguments: args, panelAttributes: attrs, id })
+      return
+    }
+    this.optimisticComponents[id] = {
+      name: component,
+      arguments: args,
+      panelAttributes: Object.assign({}, cached || {}, attrs),
+    }
+    this.scheduleOptimisticTimeout(id)
+    this.setActivePanelComponent(id)
+    Livewire.dispatch('openPanel', { component, arguments: args, panelAttributes: attrs, id })
+  },
+  closePanelOnEscape() {
+    if (this.getActiveComponentPanelAttribute('closeOnEscape') === false) return
+    const force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
+    if (this.componentHistory.length > 0) {
+      this.closePanel(false)
+      return
+    }
+    this.closePanel(force)
+  },
+  closePanelOnClickAway() {
+    if (this.getActiveComponentPanelAttribute('closeOnClickAway') === false) return
+    this.closePanel(true)
+  },
+  closePanel(force = false, skipPreviousPanels = 0, destroySkipped = false) {
+    if (this.open === false) return
+    if (this.getActiveComponentPanelAttribute('dispatchCloseEvent') === true) {
+      const serverComponents = this.$wire.get('components')
+      const componentName = serverComponents[this.activeComponent]?.name
+        ?? this.optimisticComponents[this.activeComponent]?.name
+      if (componentName) {
+        Livewire.dispatch('panelClosed', { name: componentName })
+      }
+    }
+    if (this.getActiveComponentPanelAttribute('destroyOnClose') === true) {
+      Livewire.dispatch('destroyComponent', { id: this.activeComponent })
+    }
+    if (skipPreviousPanels > 0) {
+      for (let i = 0; i < skipPreviousPanels; i++) {
+        if (destroySkipped) {
+          const id = this.componentHistory[this.componentHistory.length - 1]
+          Livewire.dispatch('destroyComponent', { id })
+        }
+        this.componentHistory.pop()
+      }
+    }
+    const id = this.componentHistory.pop()
+    if (id && !force) {
+      this.setActivePanelComponent(id, true)
+    } else {
+      this.setShowPropertyTo(false)
+    }
+  },
+  focusables() {
+    const selector = "a, button, input:not([type='hidden']), textarea, select, details, [tabindex]:not([tabindex='-1'])"
+    return [...this.$el.querySelectorAll(selector)].filter((el) => !el.hasAttribute('disabled'))
+  },
+  firstFocusable() { return this.focusables()[0] },
+  lastFocusable() { return this.focusables().slice(-1)[0] },
+  nextFocusable() { return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable() },
+  prevFocusable() { return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable() },
+  nextFocusableIndex() { return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1) },
+  prevFocusableIndex() { return Math.max(0, this.focusables().indexOf(document.activeElement)) - 1 },
+  setupListeners() {
+    this.listeners.push(
+      Livewire.on('closePanel', (data) => {
+        this.closePanel(data?.force ?? false, data?.skipPreviousPanels ?? 0, data?.destroySkipped ?? false)
+      }),
+    )
+    this.listeners.push(
+      Livewire.on('activePanelComponentChanged', ({ id }) => {
+        this.clearOptimisticTimeout(id)
+        if (!this.open && id in this.optimisticComponents) {
+          delete this.optimisticComponents[id]
+          Livewire.dispatch('destroyComponent', { id })
+          return
+        }
+        delete this.optimisticComponents[id]
+        this.setActivePanelComponent(id)
+        const server = this.$wire.get('components')[id]
+        if (server) {
+          this.writeCache(server.name, server.panelAttributes)
+          this.panelWidth = this.resizedComponents[id] ?? server.panelAttributes.maxWidthClass
+          this.panelPosition = server.panelAttributes.position ?? 'right'
+          this.closeOnEscape = server.panelAttributes.closeOnEscape ?? true
+        }
+      }),
+    )
+    this.listeners.push(
+      Livewire.on('resizeSlideOverPanel', ({ maxWidthClass, id }) => {
+        const targetId = id ?? this.activeComponent
+        if (!targetId || !maxWidthClass) return
+        if (this.resizedComponents[targetId] === maxWidthClass) return
+        requestAnimationFrame(() => {
+          this.resizedComponents = { ...this.resizedComponents, [targetId]: maxWidthClass }
+          if (targetId === this.activeComponent) {
+            this.panelWidth = maxWidthClass
+          }
+        })
+      }),
+    )
+    this.listeners.push(
+      Livewire.on('destroyComponent', ({ id }) => {
+        delete this.resizedComponents[id]
+      }),
+    )
+  },
+  exposeGlobal() {
+    const self = this
+    window.$slideOver = {
+      open(component, args = {}, attrs = {}) {
+        const id = self.deriveId(component, args)
+        self.openOptimistically(component, args, attrs, id)
+        return id
+      },
+      close(force = false) { self.closePanel(force) },
+      closeAll() { self.closePanel(true) },
+    }
+  },
+  cleanup() {
+    this.listeners.forEach((listener) => listener())
+    Object.keys(this.optimisticTimeouts).forEach((tid) => this.clearOptimisticTimeout(tid))
+    this.cancelCloseCleanup()
+    if (window.$slideOver) delete window.$slideOver
+  },
+}
+
+// === Stack ===
+
+function createStackSlideOver() {
   return {
-    open: false,
-    showActiveComponent: true,
-    activeComponent: false,
-    closeOnEscape: true,
-    componentHistory: [],
-    panelWidth: null,
-    panelPosition: 'right',
-    stacked: false,
-    listeners: [],
-    getActiveComponentPanelAttribute(key) {
-      if (this.$wire.get('components')[this.activeComponent] !== undefined) {
-        return this.$wire.get('components')[this.activeComponent]['panelAttributes'][key]
-      }
-    },
-    getComponentPanelAttribute(id, key) {
-      const components = this.$wire.get('components')
-      if (components[id] !== undefined) {
-        return components[id]['panelAttributes'][key]
-      }
-    },
+    ...slideOverCommon,
+    stacked: true,
+    inSwitch: false,
     isComponentVisible(id) {
       return id === this.activeComponent || this.componentHistory.includes(id)
     },
     getStackIndex(id) {
-      if (id === this.activeComponent) {
-        return 0
-      }
-
+      if (id === this.activeComponent) return 0
       const historyIndex = this.componentHistory.indexOf(id)
-      if (historyIndex === -1) {
-        return -1
-      }
-
+      if (historyIndex === -1) return -1
       return this.componentHistory.length - historyIndex
     },
     getStackStyle(id) {
       const index = this.getStackIndex(id)
-      if (index <= 0) {
-        return {}
-      }
-
+      if (index <= 0) return {}
       const position = this.getComponentPanelAttribute(id, 'position') ?? 'right'
       const dx = position === 'left' ? 1 : -1
       const offset = window.innerWidth < 640 ? 0.5 : 2
-
       return {
         transform: 'scale(' + (1 - 0.05 * index) + ') translateX(' + (offset * dx * index) + 'rem)',
         opacity: index <= 2 ? 1 : 0,
       }
     },
-    closePanelOnEscape(trigger) {
-      if (this.getActiveComponentPanelAttribute('closeOnEscape') === false) {
-        return
-      }
-
-      let force = this.getActiveComponentPanelAttribute('closeOnEscapeIsForceful') === true
-
-      if (this.componentHistory.length > 0) {
-        this.closePanel(false)
-        return
-      }
-
-      this.closePanel(force)
-    },
-    closePanelOnClickAway(trigger) {
-      if (this.getActiveComponentPanelAttribute('closeOnClickAway') === false) {
-        return
-      }
-
-      this.closePanel(true)
-    },
-    closePanel(force = false, skipPreviousPanels = 0, destroySkipped = false) {
-      if (this.open === false) {
-        return
-      }
-
-      if (this.getActiveComponentPanelAttribute('dispatchCloseEvent') === true) {
-        const componentName = this.$wire.get('components')[this.activeComponent].name
-        Livewire.dispatch('panelClosed', { name: componentName })
-      }
-
-      if (this.getActiveComponentPanelAttribute('destroyOnClose') === true) {
-        Livewire.dispatch('destroyComponent', { id: this.activeComponent })
-      }
-
-      if (skipPreviousPanels > 0) {
-        for (let i = 0; i < skipPreviousPanels; i++) {
-          if (destroySkipped) {
-            const id = this.componentHistory[this.componentHistory.length - 1]
-            Livewire.dispatch('destroyComponent', { id: id })
-          }
-          this.componentHistory.pop()
-        }
-      }
-
-      const id = this.componentHistory.pop()
-
-      if (id && !force) {
-        if (id) {
-          this.setActivePanelComponent(id, true)
-        } else {
-          this.setShowPropertyTo(false)
-        }
-      } else {
-        this.setShowPropertyTo(false)
-      }
-    },
     setActivePanelComponent(id, skip = false) {
       this.setShowPropertyTo(true)
-
-      if (this.activeComponent === id) {
-        return
-      }
-
+      if (this.activeComponent === id) return
       if (this.activeComponent !== false && skip === false) {
         this.componentHistory.push(this.activeComponent)
       }
-
       let focusableTimeout = 50
-
       if (this.activeComponent === false) {
         this.activeComponent = id
         this.showActiveComponent = true
@@ -127,65 +262,37 @@ window.SlideOver = () => {
         this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
         this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
       } else {
-        if (!this.stacked) {
-          this.showActiveComponent = false
-        }
-
-        focusableTimeout = 400
-
+        focusableTimeout = 600
+        this.inSwitch = true
         setTimeout(() => {
           this.activeComponent = id
           this.showActiveComponent = true
           this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
           this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
           this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
-        }, this.stacked ? 0 : 300)
+          setTimeout(() => { this.inSwitch = false }, 550)
+        }, 0)
       }
-
       this.$nextTick(() => {
-        let focusable = this.$refs[id]?.querySelector('[autofocus]')
-        if (focusable) {
-          setTimeout(() => {
-            focusable.focus()
-          }, focusableTimeout)
-        }
+        const focusable = this.$refs[id]?.querySelector('[autofocus]')
+        if (focusable) setTimeout(() => focusable.focus(), focusableTimeout)
       })
-    },
-    focusables() {
-      let selector =
-        "a, button, input:not([type='hidden']), textarea, select, details, [tabindex]:not([tabindex='-1'])"
-
-      return [...this.$el.querySelectorAll(selector)].filter((el) => !el.hasAttribute('disabled'))
-    },
-    firstFocusable() {
-      return this.focusables()[0]
-    },
-    lastFocusable() {
-      return this.focusables().slice(-1)[0]
-    },
-    nextFocusable() {
-      return this.focusables()[this.nextFocusableIndex()] || this.firstFocusable()
-    },
-    prevFocusable() {
-      return this.focusables()[this.prevFocusableIndex()] || this.lastFocusable()
-    },
-    nextFocusableIndex() {
-      return (this.focusables().indexOf(document.activeElement) + 1) % (this.focusables().length + 1)
-    },
-    prevFocusableIndex() {
-      return Math.max(0, this.focusables().indexOf(document.activeElement)) - 1
     },
     setShowPropertyTo(open) {
       this.open = open
-
       if (open) {
+        this.cancelCloseCleanup()
         document.body.classList.add('overflow-y-hidden')
       } else {
         document.body.classList.remove('overflow-y-hidden')
-
-        setTimeout(() => {
+        this.cancelCloseCleanup()
+        this._closeCleanupTimeout = setTimeout(() => {
+          this._closeCleanupTimeout = null
           this.activeComponent = false
           this.componentHistory = []
+          Object.keys(this.optimisticTimeouts).forEach((tid) => this.clearOptimisticTimeout(tid))
+          this.optimisticComponents = {}
+          this.resizedComponents = {}
           this.$wire.resetState()
         }, 300)
       }
@@ -193,24 +300,83 @@ window.SlideOver = () => {
     init() {
       this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
       this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
-      this.stacked = this.$el.dataset.stacked === 'true'
-
-      this.listeners.push(
-        Livewire.on('closePanel', (data) => {
-          this.closePanel(data?.force ?? false, data?.skipPreviousPanels ?? 0, data?.destroySkipped ?? false)
-        }),
-      )
-
-      this.listeners.push(
-        Livewire.on('activePanelComponentChanged', ({ id }) => {
-          this.setActivePanelComponent(id)
-        }),
-      )
+      this.setupListeners()
+      this.exposeGlobal()
     },
-    destroy() {
-      this.listeners.forEach((listener) => {
-        listener()
+    destroy() { this.cleanup() },
+  }
+}
+
+// === Dialog ===
+
+function createDialogSlideOver() {
+  return {
+    ...slideOverCommon,
+    stacked: false,
+
+    isComponentVisible(id) {
+      return id === this.activeComponent
+    },
+
+    setActivePanelComponent(id, skip = false) {
+      if (this.activeComponent === id) {
+        if (this.open !== true) this.setShowPropertyTo(true)
+        return
+      }
+      if (this.activeComponent !== false && skip === false) {
+        this.componentHistory.push(this.activeComponent)
+      }
+      this.activeComponent = id
+      this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+      this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+      this.closeOnEscape = this.getActiveComponentPanelAttribute('closeOnEscape') ?? true
+      this.setShowPropertyTo(true)
+
+      this.$nextTick(() => {
+        const focusable = this.$refs[id]?.querySelector('[autofocus]')
+        if (focusable) setTimeout(() => focusable.focus(), 100)
       })
     },
+
+    setShowPropertyTo(open) {
+      this.open = open
+      const dialog = this.$refs.dialog
+      if (open) {
+        this.cancelCloseCleanup()
+        if (dialog && !dialog.open && typeof dialog.showModal === 'function') {
+          dialog.showModal()
+        }
+        document.body.classList.add('overflow-y-hidden')
+      } else {
+        document.body.classList.remove('overflow-y-hidden')
+        if (dialog && dialog.open && typeof dialog.close === 'function') {
+          dialog.close()
+        }
+        this.cancelCloseCleanup()
+        this._closeCleanupTimeout = setTimeout(() => {
+          this._closeCleanupTimeout = null
+          this.activeComponent = false
+          this.componentHistory = []
+          Object.keys(this.optimisticTimeouts).forEach((tid) => this.clearOptimisticTimeout(tid))
+          this.optimisticComponents = {}
+          this.resizedComponents = {}
+          this.$wire.resetState()
+        }, 350)
+      }
+    },
+
+    init() {
+      this.panelWidth = this.getActiveComponentPanelAttribute('maxWidthClass')
+      this.panelPosition = this.getActiveComponentPanelAttribute('position') ?? 'right'
+      this.setupListeners()
+      this.exposeGlobal()
+    },
+    destroy() { this.cleanup() },
   }
+}
+
+// === Entry ===
+
+window.SlideOver = function (mode) {
+  return mode === 'dialog' ? createDialogSlideOver() : createStackSlideOver()
 }

--- a/resources/views/slide-over.blade.php
+++ b/resources/views/slide-over.blade.php
@@ -19,32 +19,32 @@
         </style>
     @endisset
 
-    <section
-        x-data="SlideOver()"
-        data-stacked="{{ $isStacked ? 'true' : 'false' }}"
-        x-on:close.stop="setShowPropertyTo(false)"
-        x-on:keydown.escape.window="closePanelOnEscape()"
-        x-show="open"
-        class="relative z-50"
-        x-ref="dialog"
-        aria-modal="true"
-        x-cloak
-    >
-        <div
-            x-cloak
+    @if ($isStacked)
+        <section
+            x-data="SlideOver('stack')"
+            data-stacked="true"
+            x-on:close.stop="setShowPropertyTo(false)"
+            x-on:keydown.escape.window="closePanelOnEscape()"
             x-show="open"
-            x-on:click="closePanelOnClickAway()"
-            x-transition:enter="duration-500 ease-in-out"
-            x-transition:enter-start="opacity-0"
-            x-transition:enter-end="opacity-100"
-            x-transition:leave="duration-500 ease-in-out"
-            x-transition:leave-start="opacity-100"
-            x-transition:leave-end="opacity-0"
-            class="fixed inset-0 bg-zinc-950/50 dark:bg-zinc-950/75"
-        ></div>
+            class="relative z-50"
+            x-ref="dialog"
+            aria-modal="true"
+            x-cloak
+        >
+            <div
+                x-cloak
+                x-show="open"
+                x-on:click="closePanelOnClickAway()"
+                x-transition:enter="duration-500 ease-in-out"
+                x-transition:enter-start="opacity-0"
+                x-transition:enter-end="opacity-100"
+                x-transition:leave="duration-500 ease-in-out"
+                x-transition:leave-start="opacity-100"
+                x-transition:leave-end="opacity-0"
+                class="fixed inset-0 bg-zinc-950/50 dark:bg-zinc-950/75"
+            ></div>
 
-        <div class="fixed inset-0">
-            @if ($isStacked)
+            <div class="fixed inset-0">
                 <div
                     @class([
                         'pointer-events-none fixed inset-y-0 grid max-w-full py-2',
@@ -62,8 +62,8 @@
                             x-transition:leave="transform transition duration-500 ease-in-out"
                             x-transition:leave-start="translate-x-0"
                             x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                            class="pointer-events-auto min-h-0 w-[calc(100vw-3rem)] sm:w-screen"
-                            x-bind:class="getComponentPanelAttribute('{{ $id }}', 'maxWidthClass') ?? panelWidth"
+                            class="pointer-events-auto min-h-0 w-[calc(100vw-3rem)] sm:w-screen ease-in-out"
+                            :class="[getComponentPanelAttribute('{{ $id }}', 'maxWidthClass') ?? panelWidth, inSwitch ? '' : 'transition-[max-width] duration-300']"
                             style="grid-area: stack"
                             wire:key="{{ $id }}"
                         >
@@ -81,48 +81,97 @@
 
                     @endforelse
                 </div>
-            @else
-                <div
-                    @class([
-                        'pointer-events-none fixed inset-y-0 flex max-w-full py-2',
-                        'left-0 pl-2 pr-10' => $isLeft,
-                        'right-0 pr-2 pl-10' => ! $isLeft,
-                    ])
-                >
-                    <div
-                        x-cloak
-                        x-show="open && showActiveComponent"
-                        x-transition:enter="transform transition duration-500 ease-in-out"
-                        x-transition:enter-start="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                        x-transition:enter-end="translate-x-0"
-                        x-transition:leave="transform transition duration-500 ease-in-out"
-                        x-transition:leave-start="translate-x-0"
-                        x-transition:leave-end="{{ $isLeft ? '-translate-x-full' : 'translate-x-full' }}"
-                        class="pointer-events-auto w-[calc(100vw-3rem)] sm:w-screen"
-                        x-bind:class="panelWidth"
-                        x-trap.noscroll.inert="open && showActiveComponent"
-                        @click.away="closePanelOnClickAway()"
-                        aria-modal="true"
-                    >
-                        <div
-                            class="h-full overflow-hidden rounded-xl bg-zinc-50 shadow-lg ring-1 ring-zinc-950/20 p-1 dark:bg-zinc-950 dark:ring-white/10"
-                        >
-                            @forelse ($components as $id => $component)
-                                <div
-                                    class="size-full min-w-0 overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-zinc-950/20 dark:bg-zinc-900 dark:ring-white/10"
-                                    x-show.immediate="activeComponent == '{{ $id }}'"
-                                    x-ref="{{ $id }}"
-                                    wire:key="{{ $id }}"
-                                >
-                                    @livewire($component['name'], $component['arguments'], key($id))
-                                </div>
-                            @empty
+            </div>
+        </section>
+    @else
+        <style wire:ignore>
+            dialog[data-livewire-slide-over] {
+                position: fixed;
+                top: 0.5rem;
+                bottom: 0.5rem;
+                {{ $isLeft ? 'left: 0.5rem; right: auto;' : 'right: 0.5rem; left: auto;' }}
+                margin: 0;
+                padding: 0;
+                border: 0;
+                background: transparent;
+                color: inherit;
+                width: calc(100vw - 3rem);
+                height: calc(100vh - 1rem);
+                max-height: calc(100vh - 1rem);
+                overflow: visible;
+                transform: translateX({{ $isLeft ? 'calc(-100% - 0.5rem)' : 'calc(100% + 0.5rem)' }});
+                transition: transform 0.35s cubic-bezier(0.32, 0.72, 0, 1), max-width 0.3s ease-in-out, display 0.35s allow-discrete;
+            }
 
-                            @endforelse
-                        </div>
+            dialog[data-livewire-slide-over]:not([open]) {
+                display: none;
+            }
+
+            dialog[data-livewire-slide-over][open] {
+                transform: translateX(0);
+            }
+
+            @starting-style {
+                dialog[data-livewire-slide-over][open] {
+                    transform: translateX({{ $isLeft ? 'calc(-100% - 0.5rem)' : 'calc(100% + 0.5rem)' }});
+                }
+            }
+
+            dialog[data-livewire-slide-over]::backdrop {
+                background-color: rgba(9, 9, 11, 0.5);
+                opacity: 0;
+                transition: opacity 0.35s ease-in-out, display 0.35s allow-discrete;
+            }
+
+            dialog[data-livewire-slide-over][open]::backdrop {
+                opacity: 1;
+            }
+
+            @starting-style {
+                dialog[data-livewire-slide-over][open]::backdrop {
+                    opacity: 0;
+                }
+            }
+
+            dialog[data-livewire-slide-over] .slide-over-panel-item {
+                position: absolute;
+                inset: 0;
+                opacity: 0;
+                pointer-events: none;
+                transition: opacity 0.2s ease-in-out;
+            }
+
+            dialog[data-livewire-slide-over] .slide-over-panel-item.is-active {
+                opacity: 1;
+                pointer-events: auto;
+            }
+        </style>
+
+        <dialog
+            wire:ignore.self
+            x-data="SlideOver('dialog')"
+            data-livewire-slide-over
+            data-stacked="false"
+            x-ref="dialog"
+            x-on:keydown.escape.prevent.stop="closePanelOnEscape()"
+            x-on:cancel.prevent
+            @click.self="closePanelOnClickAway()"
+            :class="panelWidth"
+        >
+            <div class="relative h-full w-full overflow-hidden">
+                @forelse ($components as $id => $component)
+                    <div
+                        class="slide-over-panel-item size-full overflow-hidden rounded-lg bg-white shadow-lg ring-1 ring-zinc-950/20 dark:bg-zinc-900 dark:ring-white/10"
+                        :class="activeComponent === '{{ $id }}' ? 'is-active' : ''"
+                        x-ref="{{ $id }}"
+                        wire:key="{{ $id }}"
+                    >
+                        @livewire($component['name'], $component['arguments'], key($id))
                     </div>
-                </div>
-            @endif
-        </div>
-    </section>
+                @empty
+
+                @endforelse
+            </div>
+        </dialog>
+    @endif
 </div>

--- a/src/SlideOverComponent.php
+++ b/src/SlideOverComponent.php
@@ -141,6 +141,22 @@ abstract class SlideOverComponent extends Component implements PanelContract
     }
 
     /**
+     * Dynamically resize the slide-over panel.
+     *
+     * Pass a Tailwind max-width utility class (e.g. "max-w-2xl", "max-w-6xl")
+     * or any arbitrary class string. When $id is null, the currently active
+     * panel is resized; otherwise the targeted panel is resized.
+     */
+    public function resizePanel(string $maxWidthClass, ?string $id = null): void
+    {
+        $this->dispatch(
+            'resizeSlideOverPanel',
+            maxWidthClass: $maxWidthClass,
+            id: $id,
+        );
+    }
+
+    /**
      * @param  array<int|string, mixed>  $events
      */
     public function closePanelWithEvents(array $events): void

--- a/src/SlideOverPanel.php
+++ b/src/SlideOverPanel.php
@@ -13,6 +13,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Reflector;
+use InvalidArgumentException;
 use Laravelcm\LivewireSlideOvers\Contracts\PanelContract;
 use Livewire\Attributes\Locked;
 use Livewire\Attributes\On;
@@ -92,6 +93,24 @@ class SlideOverPanel extends Component
         return $class;
     }
 
+    /**
+     * @param  class-string<SlideOverComponent>  $componentClass
+     * @return array<string, mixed>
+     */
+    protected function resolvePanelAttributes(string $componentClass): array
+    {
+        return [
+            'closeOnClickAway' => $componentClass::closePanelOnClickAway(),
+            'closeOnEscape' => $componentClass::closePanelOnEscape(),
+            'closeOnEscapeIsForceful' => $componentClass::closePanelOnEscapeIsForceful(),
+            'dispatchCloseEvent' => $componentClass::dispatchCloseEvent(),
+            'destroyOnClose' => $componentClass::destroyOnClose(),
+            'maxWidth' => $componentClass::panelMaxWidth(),
+            'maxWidthClass' => $componentClass::panelMaxWidthClass(),
+            'position' => $componentClass::panelPosition()->value,
+        ];
+    }
+
     public function resetState(): void
     {
         $this->components = [];
@@ -105,8 +124,12 @@ class SlideOverPanel extends Component
      * @throws ReflectionException
      */
     #[On('openPanel')]
-    public function openPanel(string $component, array $arguments = [], array $panelAttributes = []): void
+    public function openPanel(string $component, array $arguments = [], array $panelAttributes = [], ?string $id = null): void
     {
+        if ($id !== null && preg_match('/^[a-zA-Z0-9_-]{1,64}$/', $id) !== 1) {
+            throw new InvalidArgumentException('The slide-over panel id must contain only alphanumeric characters, underscores, or hyphens, and be between 1 and 64 characters long.');
+        }
+
         $requiredInterface = PanelContract::class;
         /** @var class-string<SlideOverComponent> $componentClass */
         $componentClass = $this->resolveComponentClass($component);
@@ -116,7 +139,7 @@ class SlideOverPanel extends Component
             throw new Exception("[{$componentClass}] does not implement [{$requiredInterface}] interface.");
         }
 
-        $id = md5($component.json_encode($arguments));
+        $id ??= md5($component.json_encode($arguments));
 
         $arguments = collect($arguments)
             ->merge($this->resolveComponentProps($arguments, new $componentClass))
@@ -125,16 +148,10 @@ class SlideOverPanel extends Component
         $this->components[$id] = [
             'name' => $component,
             'arguments' => $arguments,
-            'panelAttributes' => array_merge([
-                'closeOnClickAway' => $componentClass::closePanelOnClickAway(),
-                'closeOnEscape' => $componentClass::closePanelOnEscape(),
-                'closeOnEscapeIsForceful' => $componentClass::closePanelOnEscapeIsForceful(),
-                'dispatchCloseEvent' => $componentClass::dispatchCloseEvent(),
-                'destroyOnClose' => $componentClass::destroyOnClose(),
-                'maxWidth' => $componentClass::panelMaxWidth(),
-                'maxWidthClass' => $componentClass::panelMaxWidthClass(),
-                'position' => $componentClass::panelPosition()->value,
-            ], $panelAttributes),
+            'panelAttributes' => array_merge(
+                $this->resolvePanelAttributes($componentClass),
+                $panelAttributes,
+            ),
         ];
 
         $this->activeComponent = $id;

--- a/tests/Feature/SlideOverComponentTest.php
+++ b/tests/Feature/SlideOverComponentTest.php
@@ -75,3 +75,15 @@ it('emits events with parameters to specific component when closing panel', func
         ])
         ->assertDispatched('someEventWithParams', 'param1', 'param2');
 });
+
+it('dispatches resizeSlideOverPanel when resizing the active panel', function (): void {
+    Livewire::test(DemoSlideOver::class)
+        ->call('resizePanel', 'max-w-6xl')
+        ->assertDispatched('resizeSlideOverPanel', maxWidthClass: 'max-w-6xl', id: null);
+});
+
+it('dispatches resizeSlideOverPanel targeting a specific panel id', function (): void {
+    Livewire::test(DemoSlideOver::class)
+        ->call('resizePanel', 'max-w-2xl', 'some-panel-id')
+        ->assertDispatched('resizeSlideOverPanel', maxWidthClass: 'max-w-2xl', id: 'some-panel-id');
+});

--- a/tests/Feature/SlideOverPanelTest.php
+++ b/tests/Feature/SlideOverPanelTest.php
@@ -116,3 +116,68 @@ it('includes position in panel attributes', function (): void {
 
     expect($components[$id]['panelAttributes'])->toHaveKey('position', 'right');
 });
+
+it('uses the client-provided id when given', function (): void {
+    $component = 'demo-slide-over';
+    $arguments = ['message' => 'Optimistic'];
+    $clientId = 'so-abc123';
+
+    Livewire::test(SlideOverPanel::class)
+        ->dispatch('openPanel', component: $component, arguments: $arguments, id: $clientId)
+        ->assertSet('activeComponent', $clientId)
+        ->assertDispatched('activePanelComponentChanged', id: $clientId);
+});
+
+it('falls back to md5 id when no id is provided', function (): void {
+    $component = 'demo-slide-over';
+    $arguments = ['message' => 'Legacy path'];
+    $expectedId = md5($component.json_encode($arguments));
+
+    Livewire::test(SlideOverPanel::class)
+        ->dispatch('openPanel', component: $component, arguments: $arguments)
+        ->assertSet('activeComponent', $expectedId);
+});
+
+it('rejects ids with unsafe characters to prevent expression injection', function (string $unsafeId): void {
+    expect(
+        fn () => Livewire::test(SlideOverPanel::class)
+            ->dispatch('openPanel', component: 'demo-slide-over', id: $unsafeId)
+    )->toThrow(InvalidArgumentException::class);
+})->with([
+    'with single quote' => "foo'; alert(1); //",
+    'with double quote' => 'foo"; alert(1); //',
+    'with angle brackets' => '<script>alert(1)</script>',
+    'with spaces' => 'foo bar',
+    'with dots' => 'foo.bar',
+    'with slashes' => '../etc/passwd',
+    'with backticks' => 'foo`bar',
+]);
+
+it('rejects ids that exceed the maximum length', function (): void {
+    $tooLong = str_repeat('a', 65);
+
+    expect(
+        fn () => Livewire::test(SlideOverPanel::class)
+            ->dispatch('openPanel', component: 'demo-slide-over', id: $tooLong)
+    )->toThrow(InvalidArgumentException::class);
+});
+
+it('rejects an empty id when explicitly provided', function (): void {
+    expect(
+        fn () => Livewire::test(SlideOverPanel::class)
+            ->dispatch('openPanel', component: 'demo-slide-over', id: '')
+    )->toThrow(InvalidArgumentException::class);
+});
+
+it('accepts safe id patterns', function (string $safeId): void {
+    Livewire::test(SlideOverPanel::class)
+        ->dispatch('openPanel', component: 'demo-slide-over', id: $safeId)
+        ->assertSet('activeComponent', $safeId);
+})->with([
+    'alphanumeric' => 'abc123',
+    'with hyphen' => 'so-abc-def',
+    'with underscore' => 'panel_id_42',
+    'prefixed hash' => 'so-1y2u3w-2k9v',
+    'single char' => 'a',
+    'max length' => str_repeat('x', 64),
+]);


### PR DESCRIPTION
## Summary

Three opt-in features for the slide-over package, fully backwards-compatible with existing usage.

### 1. Instant Open (`window.$slideOver.open()`)

New JS helper that opens the drawer chrome immediately while the Livewire content hydrates inside it. After the first open of a given component in a session, all subsequent opens are instant via a `sessionStorage` cache of resolved panel attributes (max-width, position, close behaviour).

```blade
<button onclick="$slideOver.open('edit-user', { user: {{ \$user->id }} })">Edit</button>
```

Existing triggers (`Livewire.dispatch('openPanel', ...)`) keep working unchanged.

### 2. Dynamic Resize (`$this->resizePanel()`)

Components can change their panel width at runtime with a smooth animation:

```php
public function loadDetails(): void
{
    $this->resizePanel('max-w-6xl');
}
```

Accepts any Tailwind utility, including arbitrary JIT values (`max-w-[800px]`). Per-panel targeting via second `$id` argument.

### 3. Native Dialog Mode (opt-in via `'stack' => false`)

When `stack` is `false`, the slide-over renders inside a native `<dialog>` element with `showModal()`. It now lives in the browser top-layer, so it correctly stacks above other native dialogs (e.g. Flux modals) regardless of z-index. Slide-in/out animation via `@starting-style` + `allow-discrete`, single persistent backdrop, crossfade between successive panels.

Stack mode (default `'stack' => true`) is unchanged.

## Server-side `id` parameter

`openPanel` now accepts an optional `id` for client/server state reconciliation. Validated against `^[a-zA-Z0-9_-]{1,64}$` to prevent expression injection in rendered Alpine bindings. When omitted, the previous md5-based id is used (full BC).

## Tests

- 13 new Pest cases covering: client-provided id, id format validation (7 unsafe patterns, 6 safe patterns, length cap, empty), resize dispatch with and without target id.
- All 34 tests pass (47 assertions).

## Compatibility

- Livewire 3.7+ and 4.2+
- Alpine 3
- Tailwind 3+ or 4
- BC preserved: every existing API surface keeps the same signature; new features are additive.